### PR TITLE
🎨 Fix language selector dropdown styling issues

### DIFF
--- a/src/mcp_feedback_enhanced/gui/tabs/settings_tab.py
+++ b/src/mcp_feedback_enhanced/gui/tabs/settings_tab.py
@@ -191,11 +191,10 @@ class SettingsTab(QWidget):
                 height: 12px;
             }
             QComboBox QAbstractItemView {
-                background-color: #3a3a3a;
-                border: 1px solid #555555;
                 selection-background-color: #0078d4;
                 color: #ffffff;
                 font-size: 12px;
+                min-width: 120px;
             }
         """)
         


### PR DESCRIPTION

Before:

<img width="329" alt="image" src="https://github.com/user-attachments/assets/52622895-7610-4fda-9f35-9abe7fe0b5ca" />

After:

<img width="387" alt="image" src="https://github.com/user-attachments/assets/f09ea019-8e88-4030-a5be-4ff8fddde450" />
