### PR TITLE
刪除不必要標題（看起來像是AI誤生成）

### DIFF
--- a/src/mcp_feedback_enhanced/web/templates/feedback.html
+++ b/src/mcp_feedback_enhanced/web/templates/feedback.html
@@ -491,9 +491,6 @@
 
             <!-- 工作區分頁 - 移動到此位置 -->
             <div id="tab-combined" class="tab-content">
-                <div class="section-description" style="margin-bottom: 12px; padding: 8px 12px; font-size: 13px;" data-i18n="combined.description">
-                    AI 摘要和回饋輸入在同一頁面中，方便對照查看。
-                </div>
                 
                 <div class="combined-content">
                     <!-- AI 摘要區域 -->


### PR DESCRIPTION
水平佈局中的「AI 摘要和回饋輸入在同一頁面中，方便對照查看。」看起來原本是要打在註解裡面，可能是AI誤會所以寫進卡片之中了。