### PR TITLE
feat: add prompt instructions into tool docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,7 @@ For optimal results, add the following rules to your AI assistant:
 ```
 # MCP Interactive Feedback Rules
 
-1. During any process, task, or conversation, whether asking, replying, or completing phased tasks, you must call MCP mcp-feedback-enhanced.
-2. Whenever user feedback is received, if the feedback content is not empty, you must call MCP mcp-feedback-enhanced again and adjust behavior based on the feedback content.
-3. Only when the user explicitly indicates "end" or "no more interaction needed" can you stop calling MCP mcp-feedback-enhanced, and the process is considered complete.
-4. Unless receiving termination instructions, all steps must repeatedly call MCP mcp-feedback-enhanced.
-5. Before completing tasks, you must use the MCP mcp-feedback-enhanced tool to ask users for feedback.
+follow mcp-feedback-enhanced instructions
 ```
 
 ## ⚙️ Advanced Settings

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,11 +159,7 @@ uvx mcp-feedback-enhanced@latest test
 ```
 # MCP Interactive Feedback 规则
 
-1. 在任何流程、任务、对话进行时，无论是询问、回复、或完成阶段性任务，皆必须调用 MCP mcp-feedback-enhanced。
-2. 每当收到用户反馈，若反馈内容非空，必须再次调用 MCP mcp-feedback-enhanced，并根据反馈内容调整行为。
-3. 仅当用户明确表示「结束」或「不再需要交互」时，才可停止调用 MCP mcp-feedback-enhanced，流程才算结束。
-4. 除非收到结束指令，否则所有步骤都必须重复调用 MCP mcp-feedback-enhanced。
-5. 完成任务前，必须使用 MCP mcp-feedback-enhanced 工具向用户询问反馈。
+注意根据mcp-feedback-enhanced工具的要求在任务完成前进行工具调用
 ```
 
 ## ⚙️ 进阶设定

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -159,11 +159,7 @@ uvx mcp-feedback-enhanced@latest test
 ```
 # MCP Interactive Feedback 規則
 
-1. 在任何流程、任務、對話進行時，無論是詢問、回覆、或完成階段性任務，皆必須呼叫 MCP mcp-feedback-enhanced。
-2. 每當收到使用者回饋，若回饋內容非空，必須再次呼叫 MCP mcp-feedback-enhanced，並根據回饋內容調整行為。
-3. 僅當使用者明確表示「結束」或「不再需要互動」時，才可停止呼叫 MCP mcp-feedback-enhanced，流程才算結束。
-4. 除非收到結束指令，否則所有步驟都必須重複呼叫 MCP mcp-feedback-enhanced。
-5. 完成任務前，必須使用 MCP mcp-feedback-enhanced 工具向使用者詢問回饋。
+註意根據mcp-feedback-enhanced 工具的要求在任務完成前進行工具調用
 ```
 
 ## ⚙️ 進階設定

--- a/src/mcp_feedback_enhanced/server.py
+++ b/src/mcp_feedback_enhanced/server.py
@@ -37,11 +37,9 @@ from pydantic import Field
 
 # 導入統一的調試功能
 from .debug import server_debug_log as debug_log
-
 # 導入多語系支援
 # 導入錯誤處理框架
 from .utils.error_handler import ErrorHandler, ErrorType
-
 # 導入資源管理器
 from .utils.resource_manager import create_temp_file
 
@@ -115,7 +113,6 @@ REMOTE_ENV_VARS = ["REMOTE_CONTAINERS", "CODESPACES"]
 
 # 初始化 MCP 服務器
 from . import __version__
-
 
 # 確保 log_level 設定為正確的大寫格式
 fastmcp_settings = {}
@@ -435,19 +432,11 @@ async def interactive_feedback(
     timeout: Annotated[int, Field(description="等待用戶回饋的超時時間（秒）")] = 600,
 ) -> list:
     """
-    收集用戶的互動回饋，支援文字和圖片
-
-    此工具使用 Web UI 介面收集用戶回饋，支援智能環境檢測。
-
-    用戶可以：
-    1. 執行命令來驗證結果
-    2. 提供文字回饋
-    3. 上傳圖片作為回饋
-    4. 查看 AI 的工作摘要
-
-    調試模式：
-    - 設置環境變數 MCP_DEBUG=true 可啟用詳細調試輸出
-    - 生產環境建議關閉調試模式以避免輸出干擾
+    1. During any process, task, or conversation, whether asking, replying, or completing phased tasks, you must call this tool to ask for feedback.
+    2. Unless receiving termination instructions, all steps must repeatedly call this tool.
+    3. Whenever user feedback is received, if the feedback content is not empty, you must call this tool again and adjust behavior based on the feedback content.
+    4. Only when the user explicitly indicates "end" or "no more interaction needed" can you stop calling this tool, and the process is considered complete.
+    5. You should summary what have done, and provide project directory through args to let user know what you have done to provide feedback for next step.
 
     Args:
         project_directory: 專案目錄路徑
@@ -599,7 +588,22 @@ def get_system_info() -> str:
 
 # ===== 主程式入口 =====
 def main():
-    """主要入口點，用於套件執行"""
+    """主要入口點，用於套件執行
+    收集用戶的互動回饋，支援文字和圖片
+    此工具使用 Web UI 介面收集用戶回饋，支援智能環境檢測。
+
+    用戶可以：
+    1. 執行命令來驗證結果
+    2. 提供文字回饋
+    3. 上傳圖片作為回饋
+    4. 查看 AI 的工作摘要
+
+    調試模式：
+    - 設置環境變數 MCP_DEBUG=true 可啟用詳細調試輸出
+    - 生產環境建議關閉調試模式以避免輸出干擾
+
+
+    """
     # 檢查是否啟用調試模式
     debug_enabled = os.getenv("MCP_DEBUG", "").lower() in ("true", "1", "yes", "on")
 


### PR DESCRIPTION
根据fastmcp的文档 https://gofastmcp.com/servers/tools, 工具装饰器会将相关的函数的docstring自动转成工具的描述，附加在大模型的调用promt中。
原来的docstring是面向于用户及开发者的函数描述，对于模型来说指导意义不大，且浪费模型调用token。
这个PR将原本README中推荐加入到cursor rule的描述（同样也会加入到大模型的调用promt中）加到了工具的docstring中，这样：

1. 可以简化用户配置
2. 精减大模型的输入token, 避免副作用
3. 为了保险起见，建议用户配置cursor rule，进一步提醒模型注意对工具的调用