### PR TITLE
Add MCP tool annotations for better AI understanding

### DIFF
--- a/src/mcp_feedback_enhanced/server.py
+++ b/src/mcp_feedback_enhanced/server.py
@@ -32,7 +32,7 @@ from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from fastmcp.utilities.types import Image as MCPImage
-from mcp.types import TextContent
+from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field
 
 # 導入統一的調試功能
@@ -426,7 +426,13 @@ def process_images(images_data: list[dict]) -> list[MCPImage]:
 
 
 # ===== MCP 工具定義 =====
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Interactive Feedback",
+        readOnlyHint=False,  # Creates temporary files for feedback storage
+        destructiveHint=False,  # Does not modify or delete user data
+    )
+)
 async def interactive_feedback(
     project_directory: Annotated[str, Field(description="專案目錄路徑")] = ".",
     summary: Annotated[
@@ -559,7 +565,13 @@ async def launch_web_feedback_ui(project_dir: str, summary: str, timeout: int) -
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Get System Info",
+        readOnlyHint=True,  # Only reads system environment information
+        destructiveHint=False,
+    )
+)
 def get_system_info() -> str:
     """
     獲取系統環境資訊


### PR DESCRIPTION
## Summary

Add MCP tool annotations to help AI assistants understand tool capabilities and behavior.

**Changes:**
- `interactive_feedback`: `readOnlyHint=False` (creates temp files for feedback storage), `destructiveHint=False`
- `get_system_info`: `readOnlyHint=True` (only reads system environment), `destructiveHint=False`

## Why this matters

[MCP Tool Annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations) provide hints to AI assistants about tool behavior:
- `readOnlyHint`: Indicates whether the tool modifies state
- `destructiveHint`: Indicates whether the tool makes irreversible changes

These annotations help AI assistants make better decisions about:
- Whether to confirm before executing a tool
- Risk assessment for tool execution
- Grouping similar operations

## Test plan

- [ ] Verify both tools still function correctly
- [ ] Confirm annotations are visible in MCP inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)