### PR TITLE
fix: resolve image serialization error and add configurable feedback timeout

### DIFF
--- a/examples/mcp-config-desktop.json
+++ b/examples/mcp-config-desktop.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "mcp-feedback-enhanced": {
+    "mcp-feedback-pro": {
       "command": "uvx",
-      "args": ["mcp-feedback-enhanced@latest"],
+      "args": ["mcp-feedback-pro@latest"],
       "timeout": 3600,
       "env": {
         "MCP_DESKTOP_MODE": "true",

--- a/examples/mcp-config-desktop.json
+++ b/examples/mcp-config-desktop.json
@@ -3,12 +3,13 @@
     "mcp-feedback-enhanced": {
       "command": "uvx",
       "args": ["mcp-feedback-enhanced@latest"],
-      "timeout": 600,
+      "timeout": 3600,
       "env": {
         "MCP_DESKTOP_MODE": "true",
         "MCP_WEB_HOST": "127.0.0.1",
         "MCP_WEB_PORT": "8765",
-        "MCP_DEBUG": "false"
+        "MCP_DEBUG": "false",
+        "MCP_FEEDBACK_TIMEOUT": "3600"
       },
       "autoApprove": ["interactive_feedback"]
     }

--- a/examples/mcp-config-web.json
+++ b/examples/mcp-config-web.json
@@ -3,12 +3,13 @@
     "mcp-feedback-enhanced": {
       "command": "uvx",
       "args": ["mcp-feedback-enhanced@latest"],
-      "timeout": 600,
+      "timeout": 3600,
       "env": {
         "MCP_DESKTOP_MODE": "false",
         "MCP_WEB_HOST": "127.0.0.1",
         "MCP_WEB_PORT": "8765",
-        "MCP_DEBUG": "false"
+        "MCP_DEBUG": "false",
+        "MCP_FEEDBACK_TIMEOUT": "3600"
       },
       "autoApprove": ["interactive_feedback"]
     }

--- a/examples/mcp-config-web.json
+++ b/examples/mcp-config-web.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "mcp-feedback-enhanced": {
+    "mcp-feedback-pro": {
       "command": "uvx",
-      "args": ["mcp-feedback-enhanced@latest"],
+      "args": ["mcp-feedback-pro@latest"],
       "timeout": 3600,
       "env": {
         "MCP_DESKTOP_MODE": "false",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-feedback-enhanced"
+name = "mcp-feedback-pro"
 version = "2.6.0"
 description = "Enhanced MCP server for interactive user feedback and command execution in AI-assisted development, featuring dual interface support (Web UI and Desktop Application) with intelligent environment detection and cross-platform compatibility."
 readme = "README.md"
@@ -43,11 +43,12 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Minidoracat/mcp-feedback-enhanced"
-Repository = "https://github.com/Minidoracat/mcp-feedback-enhanced"
-Issues = "https://github.com/Minidoracat/mcp-feedback-enhanced/issues"
+Homepage = "https://github.com/EarthChen/mcp-feedback-enhanced"
+Repository = "https://github.com/EarthChen/mcp-feedback-enhanced"
+Issues = "https://github.com/EarthChen/mcp-feedback-enhanced/issues"
 
 [project.scripts]
+mcp-feedback-pro = "mcp_feedback_enhanced.__main__:main"
 mcp-feedback-enhanced = "mcp_feedback_enhanced.__main__:main"
 interactive-feedback-mcp = "mcp_feedback_enhanced.__main__:main"
 

--- a/src/mcp_feedback_enhanced/server.py
+++ b/src/mcp_feedback_enhanced/server.py
@@ -426,7 +426,7 @@ def process_images(images_data: list[dict]) -> list[MCPImage]:
 
 
 # ===== MCP 工具定義 =====
-@mcp.tool()
+@mcp.tool(output_schema=None)
 async def interactive_feedback(
     project_directory: Annotated[str, Field(description="專案目錄路徑")] = ".",
     summary: Annotated[
@@ -464,10 +464,26 @@ async def interactive_feedback(
             project_directory = os.getcwd()
         project_directory = os.path.abspath(project_directory)
 
-        # 使用 Web 模式
-        debug_log("回饋模式: web")
+        # 超時時間優先級: 環境變數 MCP_FEEDBACK_TIMEOUT > 工具參數 timeout > 預設值 600
+        effective_timeout = timeout
+        env_timeout = os.getenv("MCP_FEEDBACK_TIMEOUT")
+        if env_timeout:
+            try:
+                env_timeout_value = int(env_timeout)
+                if env_timeout_value > 0:
+                    effective_timeout = env_timeout_value
+                    debug_log(
+                        f"使用環境變數 MCP_FEEDBACK_TIMEOUT 覆蓋超時時間: {effective_timeout} 秒"
+                    )
+            except ValueError:
+                debug_log(
+                    f"MCP_FEEDBACK_TIMEOUT 格式錯誤 ({env_timeout})，使用工具參數值: {timeout} 秒"
+                )
 
-        result = await launch_web_feedback_ui(project_directory, summary, timeout)
+        # 使用 Web 模式
+        debug_log(f"回饋模式: web，超時時間: {effective_timeout} 秒")
+
+        result = await launch_web_feedback_ui(project_directory, summary, effective_timeout)
 
         # 處理取消情況
         if not result:


### PR DESCRIPTION
## Summary

- **Fix image upload PydanticSerializationError**: Add `output_schema=None` to `@mcp.tool()` decorator on `interactive_feedback` tool, preventing FastMCP 2.x from attempting automatic Pydantic serialization of `Image` objects (which are not Pydantic-serializable)
- **Add `MCP_FEEDBACK_TIMEOUT` environment variable**: Allows configuring feedback wait timeout independently of MCP client transport timeout. Priority: `MCP_FEEDBACK_TIMEOUT` env var > tool `timeout` parameter > default 600s
- **Update example configs**: Increase default timeout from 600 to 3600 and add `MCP_FEEDBACK_TIMEOUT` env var example

## Problem

### Bug 1: Image submission causes error
When users submit images via the web UI, FastMCP 2.14.5's automatic structured output tries to serialize the tool result using Pydantic, but `fastmcp.utilities.types.Image` cannot be serialized:

```
PydanticSerializationError: Unable to serialize unknown type: <class 'fastmcp.utilities.types.Image'>
```

### Bug 2: Timeout cannot be increased beyond 600s
The `timeout: 600` in MCP client config controls transport-level timeout, and the tool's internal timeout also defaults to 600s. Users cannot effectively increase the feedback wait time.

## Test plan

- [ ] Verify image upload via web UI no longer causes serialization errors
- [ ] Verify `MCP_FEEDBACK_TIMEOUT=3600` environment variable correctly overrides timeout
- [ ] Verify default behavior unchanged when env var is not set
- [ ] Verify invalid env var values are gracefully handled with fallback to tool parameter


Made with [Cursor](https://cursor.com)