### PR TITLE
Fix TemplateResponse crash with Starlette 0.38+ (TypeError: unhashable type: 'dict')

### DIFF
--- a/src/mcp_feedback_enhanced/web/routes/main_routes.py
+++ b/src/mcp_feedback_enhanced/web/routes/main_routes.py
@@ -62,9 +62,9 @@ def setup_routes(manager: "WebUIManager"):
         if not current_session:
             # 沒有活躍會話時顯示等待頁面
             return manager.templates.TemplateResponse(
+                request,
                 "index.html",
-                {
-                    "request": request,
+                context={
                     "title": "MCP Feedback Enhanced",
                     "has_session": False,
                     "version": __version__,
@@ -76,9 +76,9 @@ def setup_routes(manager: "WebUIManager"):
         layout_mode = load_user_layout_settings()
 
         return manager.templates.TemplateResponse(
+            request,
             "feedback.html",
-            {
-                "request": request,
+            context={
                 "project_directory": current_session.project_directory,
                 "summary": current_session.summary,
                 "title": "Interactive Feedback - 回饋收集",


### PR DESCRIPTION
## Summary

- **Fixes a critical bug** where the Web UI returns `500 Internal Server Error` on every page load due to a Starlette API breaking change.
- Updates `TemplateResponse` calls to use the new Starlette 0.38+ API signature.

## Problem

Starlette 0.38.0 (released as part of FastAPI 0.115+) introduced a **breaking change** to the `Jinja2Templates.TemplateResponse` API:

| | Old Signature (< 0.38) | New Signature (>= 0.38) |
|---|---|---|
| **1st arg** | `name` (template name) | `request` (Request object) |
| **2nd arg** | `context` (dict with `"request"` key) | `name` (template name) |
| **3rd arg** | — | `context` (dict, no `"request"` key needed) |

The existing code used the **old** calling convention:

```python
manager.templates.TemplateResponse(
    "index.html",                         # interpreted as `request` in new API
    {"request": request, "title": ...},   # interpreted as `name` in new API
)
```

With Starlette 0.38+, the dict passed as the second argument is interpreted as the template `name`. When Jinja2 tries to use this dict as a cache lookup key, it raises:

```
TypeError: unhashable type: 'dict'
```

This causes a **500 Internal Server Error** on every page load (`/` endpoint), making the entire Web UI completely unusable.

Since `pyproject.toml` specifies `fastapi>=0.115.0` (which depends on `starlette>=0.38`), **all fresh installations are affected**.

## Fix

Updated both `TemplateResponse` calls in `main_routes.py` to use the new positional argument order:

```python
manager.templates.TemplateResponse(
    request,            # 1st arg: Request object
    "index.html",       # 2nd arg: template name
    context={...},      # keyword arg: context (no "request" key needed)
)
```

## Files Changed

- `src/mcp_feedback_enhanced/web/routes/main_routes.py` — 2 `TemplateResponse` calls updated (lines 64 and 78)

## Test Plan

- [x] `make test-web` passes — server starts successfully, no `TypeError` or `500` errors
- [x] Manual verification: open `http://127.0.0.1:<port>/` in browser, confirm page loads correctly
- [x] Verify both code paths: with active session (`feedback.html`) and without (`index.html`)