### PR TITLE
fix: update TemplateResponse calls for Starlette compatibility

### DIFF
--- a/src/mcp_feedback_enhanced/web/routes/main_routes.py
+++ b/src/mcp_feedback_enhanced/web/routes/main_routes.py
@@ -62,6 +62,7 @@ def setup_routes(manager: "WebUIManager"):
         if not current_session:
             # 沒有活躍會話時顯示等待頁面
             return manager.templates.TemplateResponse(
+                request,
                 "index.html",
                 {
                     "request": request,
@@ -76,6 +77,7 @@ def setup_routes(manager: "WebUIManager"):
         layout_mode = load_user_layout_settings()
 
         return manager.templates.TemplateResponse(
+            request,
             "feedback.html",
             {
                 "request": request,


### PR DESCRIPTION
## Summary
- update the two `TemplateResponse` calls in `src/mcp_feedback_enhanced/web/routes/main_routes.py` to pass `request` as the first positional argument
- fix the Web UI crash on newer Starlette versions where the old positional API now raises `TypeError: unhashable type: 'dict'`

## Reproduction
- install `mcp-feedback-enhanced 2.6.0`
- start the Web UI with a dependency set that includes newer Starlette (I reproduced this locally with `fastapi 0.135.1` + `starlette 1.0.0`)
- open `http://127.0.0.1:8765/`
- observe `500 Internal Server Error`

## Root cause
`Jinja2Templates.TemplateResponse` now expects:

```python
TemplateResponse(request, name, context=...)
```

but the current code still uses the old positional order:

```python
TemplateResponse("index.html", {"request": request, ...})
```

which causes Starlette/Jinja2 to treat the context dict as the template name.

## Test plan
- [x] verify the Python file still compiles
- [x] reproduce the 500 locally before the change
- [x] apply the same fix locally in the installed package and verify the page returns `200 OK`
- [ ] CI / maintainer verification

## Note
I noticed there are already open PRs touching the same issue. This PR is intentionally kept minimal and only changes the two broken call sites.