### PR TITLE
fix(web): update TemplateResponse to new Starlette API

### DIFF
--- a/src/mcp_feedback_enhanced/web/routes/main_routes.py
+++ b/src/mcp_feedback_enhanced/web/routes/main_routes.py
@@ -62,9 +62,9 @@ def setup_routes(manager: "WebUIManager"):
         if not current_session:
             # 沒有活躍會話時顯示等待頁面
             return manager.templates.TemplateResponse(
+                request,
                 "index.html",
-                {
-                    "request": request,
+                context={
                     "title": "MCP Feedback Enhanced",
                     "has_session": False,
                     "version": __version__,
@@ -76,9 +76,9 @@ def setup_routes(manager: "WebUIManager"):
         layout_mode = load_user_layout_settings()
 
         return manager.templates.TemplateResponse(
+            request,
             "feedback.html",
-            {
-                "request": request,
+            context={
                 "project_directory": current_session.project_directory,
                 "summary": current_session.summary,
                 "title": "Interactive Feedback - 回饋收集",

--- a/src/mcp_feedback_enhanced/web/routes/main_routes.py
+++ b/src/mcp_feedback_enhanced/web/routes/main_routes.py
@@ -79,6 +79,7 @@ def setup_routes(manager: "WebUIManager"):
             request,
             "feedback.html",
             context={
+                "session_id": current_session.session_id,
                 "project_directory": current_session.project_directory,
                 "summary": current_session.summary,
                 "title": "Interactive Feedback - 回饋收集",


### PR DESCRIPTION
## Problem

When running `uvx mcp-feedback-enhanced@latest test --desktop`, the app crashes with:

```
TypeError: unhashable type: 'dict'
```

## Root Cause

Starlette changed the `TemplateResponse` signature (breaking change):

| | Old API | New API |
|---|---|---|
| Signature | `TemplateResponse(name, context_dict)` | `TemplateResponse(request, name, context=...)` |
| `request` position | Inside `context` dict | First argument |

The old calling convention passed the `context dict` as the `name` parameter, which Jinja2 then tried to use as a cache key — but `dict` is not hashable, causing the crash.

## Fix

Updated both `TemplateResponse` calls in `main_routes.py` to use the new Starlette API:

```python
# Before (broken)
manager.templates.TemplateResponse(
    "feedback.html",
    {"request": request, "title": ..., ...},
)

# After (fixed)
manager.templates.TemplateResponse(
    request,
    "feedback.html",
    context={"title": ..., ...},
)
```

## Testing

Verified locally with `uvx --from . mcp-feedback-enhanced test --desktop` — no errors, templates render correctly.