### PR TITLE
会话历史在前端加载过程中被实时列表覆盖，只保留最新记录，较早会话丢失。

### DIFF
--- a/src/mcp_feedback_enhanced/web/main.py
+++ b/src/mcp_feedback_enhanced/web/main.py
@@ -117,8 +117,10 @@ class WebUIManager:
         # 全局標籤頁狀態管理 - 跨會話保持
         self.global_active_tabs: dict[str, dict] = {}
 
-        # 會話更新通知標記
-        self._pending_session_update = False
+        # 會話更新通知標記（按會話追蹤）
+        self._pending_session_updates: set[str] = set()
+        # 工作區最新會話映射（key: project_directory）
+        self.workspace_current_sessions: dict[str, str] = {}
 
         # 會話清理統計
         self.cleanup_stats: dict[str, Any] = {
@@ -326,10 +328,21 @@ class WebUIManager:
         else:
             raise RuntimeError(f"Templates directory not found: {web_templates_path}")
 
+    def _workspace_key(self, project_directory: str) -> str:
+        """生成工作區 key（用於多工作區並行會話）"""
+        return str(Path(project_directory).resolve())
+
+    def get_session_by_id(self, session_id: str | None) -> WebFeedbackSession | None:
+        """根據 session_id 取得會話，若未提供則回退到當前活躍會話"""
+        if session_id:
+            return self.sessions.get(session_id)
+        return self.current_session
+
     def create_session(self, project_directory: str, summary: str) -> str:
-        """創建新的回饋會話 - 重構為單一活躍會話模式，保留標籤頁狀態"""
-        # 保存舊會話的引用和 WebSocket 連接
-        old_session = self.current_session
+        """創建新的回饋會話 - 支援多工作區並行會話"""
+        workspace_key = self._workspace_key(project_directory)
+        old_session_id = self.workspace_current_sessions.get(workspace_key)
+        old_session = self.sessions.get(old_session_id) if old_session_id else None
         old_websocket = None
         if old_session and old_session.websocket:
             old_websocket = old_session.websocket
@@ -377,8 +390,9 @@ class WebUIManager:
         # 將全局標籤頁狀態繼承到新會話
         session.active_tabs = self.global_active_tabs.copy()
 
-        # 設置為當前活躍會話
+        # 設置為當前活躍會話，並更新工作區映射
         self.current_session = session
+        self.workspace_current_sessions[workspace_key] = session_id
         # 同時保存到字典中以保持向後兼容
         self.sessions[session_id] = session
 
@@ -391,9 +405,9 @@ class WebUIManager:
             session.websocket = old_websocket
             debug_log("已將舊 WebSocket 連接轉移到新會話")
         else:
-            # 沒有舊連接，標記需要發送會話更新通知（當新 WebSocket 連接建立時）
-            self._pending_session_update = True
-            debug_log("沒有舊 WebSocket 連接，設置待更新標記")
+            # 沒有舊連接，標記該會話需要發送更新通知（當該會話 WebSocket 連接建立時）
+            self._pending_session_updates.add(session_id)
+            debug_log(f"沒有舊 WebSocket 連接，設置待更新標記: {session_id}")
 
         return session_id
 
@@ -409,8 +423,12 @@ class WebUIManager:
         """移除回饋會話"""
         if session_id in self.sessions:
             session = self.sessions[session_id]
+            workspace_key = self._workspace_key(session.project_directory)
             session.cleanup()
             del self.sessions[session_id]
+            self._pending_session_updates.discard(session_id)
+            if self.workspace_current_sessions.get(workspace_key) == session_id:
+                self.workspace_current_sessions.pop(workspace_key, None)
 
             # 如果移除的是當前活躍會話，清空當前會話
             if self.current_session and self.current_session.session_id == session_id:
@@ -423,12 +441,16 @@ class WebUIManager:
         """清空當前活躍會話"""
         if self.current_session:
             session_id = self.current_session.session_id
+            workspace_key = self._workspace_key(self.current_session.project_directory)
             self.current_session.cleanup()
             self.current_session = None
 
             # 同時從字典中移除
             if session_id in self.sessions:
                 del self.sessions[session_id]
+            self._pending_session_updates.discard(session_id)
+            if self.workspace_current_sessions.get(workspace_key) == session_id:
+                self.workspace_current_sessions.pop(workspace_key, None)
 
             debug_log("已清空當前活躍會話")
 
@@ -887,6 +909,10 @@ class WebUIManager:
                     ):
                         self.current_session = None
                         debug_log("清空過期的當前活躍會話")
+                    self._pending_session_updates.discard(session_id)
+                    workspace_key = self._workspace_key(session.project_directory)
+                    if self.workspace_current_sessions.get(workspace_key) == session_id:
+                        self.workspace_current_sessions.pop(workspace_key, None)
 
             except Exception as e:
                 error_id = ErrorHandler.log_error_with_context(
@@ -971,6 +997,10 @@ class WebUIManager:
                 ):
                     self.current_session = None
                     debug_log("因內存壓力清空當前活躍會話")
+                self._pending_session_updates.discard(session_id)
+                workspace_key = self._workspace_key(session.project_directory)
+                if self.workspace_current_sessions.get(workspace_key) == session_id:
+                    self.workspace_current_sessions.pop(workspace_key, None)
 
             except Exception as e:
                 error_id = ErrorHandler.log_error_with_context(
@@ -1060,6 +1090,8 @@ class WebUIManager:
 
         self.sessions.clear()
         self.current_session = None
+        self._pending_session_updates.clear()
+        self.workspace_current_sessions.clear()
 
         # 更新統計
         cleanup_duration = time.time() - cleanup_start_time
@@ -1113,7 +1145,7 @@ async def launch_web_feedback_ui(
     manager = get_web_ui_manager()
 
     # 創建新會話（每次AI調用都應該創建新會話）
-    manager.create_session(project_directory, summary)
+    session_id = manager.create_session(project_directory, summary)
     session = manager.get_current_session()
 
     if not session:
@@ -1127,7 +1159,7 @@ async def launch_web_feedback_ui(
     desktop_mode = os.environ.get("MCP_DESKTOP_MODE", "").lower() == "true"
 
     # 使用根路徑 URL
-    feedback_url = manager.get_server_url()  # 直接使用根路徑
+    feedback_url = f"{manager.get_server_url()}/?session_id={session_id}"
 
     if desktop_mode:
         # 桌面模式：啟動桌面應用程式

--- a/src/mcp_feedback_enhanced/web/routes/main_routes.py
+++ b/src/mcp_feedback_enhanced/web/routes/main_routes.py
@@ -54,10 +54,10 @@ def setup_routes(manager: "WebUIManager"):
     """設置路由"""
 
     @manager.app.get("/", response_class=HTMLResponse)
-    async def index(request: Request):
+    async def index(request: Request, session_id: str | None = None):
         """統一回饋頁面 - 重構後的主頁面"""
         # 獲取當前活躍會話
-        current_session = manager.get_current_session()
+        current_session = manager.get_session_by_id(session_id)
 
         if not current_session:
             # 沒有活躍會話時顯示等待頁面
@@ -85,6 +85,7 @@ def setup_routes(manager: "WebUIManager"):
                 "version": __version__,
                 "has_session": True,
                 "layout_mode": layout_mode,
+                "session_id": current_session.session_id,
             },
         )
 
@@ -118,9 +119,9 @@ def setup_routes(manager: "WebUIManager"):
         return JSONResponse(content=translations)
 
     @manager.app.get("/api/session-status")
-    async def get_session_status(request: Request):
+    async def get_session_status(request: Request, session_id: str | None = None):
         """獲取當前會話狀態"""
-        current_session = manager.get_current_session()
+        current_session = manager.get_session_by_id(session_id)
 
         # 從請求頭獲取客戶端語言
         lang = (
@@ -151,9 +152,9 @@ def setup_routes(manager: "WebUIManager"):
         )
 
     @manager.app.get("/api/current-session")
-    async def get_current_session(request: Request):
+    async def get_current_session(request: Request, session_id: str | None = None):
         """獲取當前會話詳細信息"""
-        current_session = manager.get_current_session()
+        current_session = manager.get_session_by_id(session_id)
 
         # 從查詢參數獲取語言，如果沒有則從會話獲取，最後使用默認值
 
@@ -183,6 +184,7 @@ def setup_routes(manager: "WebUIManager"):
 
         try:
             sessions_data = []
+            active_session_ids = set()
 
             # 獲取所有會話的實時狀態
             for session_id, session in manager.sessions.items():
@@ -200,11 +202,52 @@ def setup_routes(manager: "WebUIManager"):
                     "user_messages": session.user_messages,  # 包含用戶消息記錄
                 }
                 sessions_data.append(session_info)
+                active_session_ids.add(session.session_id)
+
+            # 補充歷史檔案中的會話，避免只有最新會話被返回而覆蓋更早歷史
+            config_dir = Path.home() / ".config" / "mcp-feedback-enhanced"
+            history_file = config_dir / "session_history.json"
+            historical_sessions = []
+
+            if history_file.exists():
+                with open(history_file, encoding="utf-8") as f:
+                    history_data = json.load(f)
+
+                if isinstance(history_data, dict):
+                    historical_sessions = history_data.get("sessions", [])
+                elif isinstance(history_data, list):
+                    # 向後相容舊格式
+                    historical_sessions = history_data
+
+            if isinstance(historical_sessions, list):
+                for historical_session in historical_sessions:
+                    if not isinstance(historical_session, dict):
+                        continue
+
+                    historical_session_id = historical_session.get("session_id")
+                    if (
+                        not historical_session_id
+                        or historical_session_id in active_session_ids
+                    ):
+                        continue
+
+                    sessions_data.append(historical_session)
 
             # 按創建時間排序（最新的在前）
-            sessions_data.sort(key=lambda x: x["created_at"], reverse=True)
+            sessions_data.sort(
+                key=lambda x: (
+                    x.get("created_at")
+                    or x.get("saved_at")
+                    or x.get("last_activity")
+                    or 0
+                ),
+                reverse=True,
+            )
 
-            debug_log(f"返回 {len(sessions_data)} 個會話的實時狀態")
+            historical_count = max(len(sessions_data) - len(active_session_ids), 0)
+            debug_log(
+                f"返回 {len(sessions_data)} 個會話狀態（即時: {len(active_session_ids)}，歷史補充: {historical_count}）"
+            )
             return JSONResponse(content={"sessions": sessions_data})
 
         except Exception as e:
@@ -218,12 +261,12 @@ def setup_routes(manager: "WebUIManager"):
             )
 
     @manager.app.post("/api/add-user-message")
-    async def add_user_message(request: Request):
+    async def add_user_message(request: Request, session_id: str | None = None):
         """添加用戶消息到當前會話"""
 
         try:
             data = await request.json()
-            current_session = manager.get_current_session()
+            current_session = manager.get_session_by_id(session_id)
 
             if not current_session:
                 return JSONResponse(
@@ -256,10 +299,11 @@ def setup_routes(manager: "WebUIManager"):
             )
 
     @manager.app.websocket("/ws")
-    async def websocket_endpoint(websocket: WebSocket, lang: str = "zh-TW"):
-        """WebSocket 端點 - 重構後移除 session_id 依賴"""
-        # 獲取當前活躍會話
-        session = manager.get_current_session()
+    async def websocket_endpoint(
+        websocket: WebSocket, lang: str = "zh-TW", session_id: str | None = None
+    ):
+        """WebSocket 端點 - 支援按 session_id 綁定會話"""
+        session = manager.get_session_by_id(session_id)
         if not session:
             await websocket.close(code=4004, reason="No active session")
             return
@@ -285,8 +329,8 @@ def setup_routes(manager: "WebUIManager"):
                 }
             )
 
-            # 檢查是否有待發送的會話更新
-            if getattr(manager, "_pending_session_update", False):
+            # 檢查是否有待發送的會話更新（按會話）
+            if session.session_id in getattr(manager, "_pending_session_updates", set()):
                 debug_log("檢測到待發送的會話更新，準備發送通知")
                 await websocket.send_json(
                     {
@@ -300,7 +344,7 @@ def setup_routes(manager: "WebUIManager"):
                         },
                     }
                 )
-                manager._pending_session_update = False
+                manager._pending_session_updates.discard(session.session_id)
                 debug_log("✅ 已發送會話更新通知到前端")
             else:
                 # 發送當前會話狀態
@@ -317,12 +361,11 @@ def setup_routes(manager: "WebUIManager"):
                 data = await websocket.receive_text()
                 message = json.loads(data)
 
-                # 重新獲取當前會話，以防會話已切換
-                current_session = manager.get_current_session()
-                if current_session and current_session.websocket == websocket:
-                    await handle_websocket_message(manager, current_session, message)
+                bound_session = manager.get_session_by_id(session.session_id)
+                if bound_session and bound_session.websocket == websocket:
+                    await handle_websocket_message(manager, bound_session, message)
                 else:
-                    debug_log("會話已切換或 WebSocket 連接不匹配，忽略消息")
+                    debug_log("綁定會話不存在或 WebSocket 連接不匹配，忽略消息")
                     break
 
         except WebSocketDisconnect:
@@ -333,9 +376,9 @@ def setup_routes(manager: "WebUIManager"):
             debug_log(f"WebSocket 錯誤: {e}")
         finally:
             # 安全清理 WebSocket 連接
-            current_session = manager.get_current_session()
-            if current_session and current_session.websocket == websocket:
-                current_session.websocket = None
+            bound_session = manager.get_session_by_id(session.session_id)
+            if bound_session and bound_session.websocket == websocket:
+                bound_session.websocket = None
                 debug_log("已清理會話中的 WebSocket 連接")
 
     @manager.app.post("/api/save-settings")

--- a/src/mcp_feedback_enhanced/web/static/js/app.js
+++ b/src/mcp_feedback_enhanced/web/static/js/app.js
@@ -20,8 +20,9 @@
      */
     function FeedbackApp(sessionId) {
         // 會話信息
-        this.sessionId = sessionId;
-        this.currentSessionId = null;
+        const urlSessionId = new URLSearchParams(window.location.search).get('session_id');
+        this.sessionId = sessionId || urlSessionId || null;
+        this.currentSessionId = this.sessionId;
 
         // 模組管理器
         this.tabManager = null;
@@ -209,6 +210,7 @@
                         self.webSocketManager = new window.MCPFeedback.WebSocketManager({
                             tabManager: self.tabManager,
                             connectionMonitor: self.connectionMonitor,
+                            sessionId: self.currentSessionId,
                             onOpen: function() {
                                 self.handleWebSocketOpen();
                             },
@@ -1683,7 +1685,10 @@
 
         const self = this;
 
-        fetch('/api/current-session')
+        const sessionQuery = this.currentSessionId
+            ? '?session_id=' + encodeURIComponent(this.currentSessionId)
+            : '';
+        fetch('/api/current-session' + sessionQuery)
             .then(function(response) {
                 if (!response.ok) {
                     throw new Error('API 請求失敗: ' + response.status);

--- a/src/mcp_feedback_enhanced/web/static/js/modules/session/session-data-manager.js
+++ b/src/mcp_feedback_enhanced/web/static/js/modules/session/session-data-manager.js
@@ -399,7 +399,13 @@
      */
     SessionDataManager.prototype.sendUserMessageToServer = function(userMessage) {
         const lang = window.i18nManager ? window.i18nManager.getCurrentLanguage() : 'zh-TW';
-        fetch('/api/add-user-message?lang=' + lang, {
+        const sessionId = this.currentSession && this.currentSession.session_id ? this.currentSession.session_id : null;
+        const queryParams = new URLSearchParams();
+        queryParams.set('lang', lang);
+        if (sessionId) {
+            queryParams.set('session_id', sessionId);
+        }
+        fetch('/api/add-user-message?' + queryParams.toString(), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/mcp_feedback_enhanced/web/static/js/modules/session/session-data-manager.js
+++ b/src/mcp_feedback_enhanced/web/static/js/modules/session/session-data-manager.js
@@ -93,6 +93,77 @@
     };
 
     /**
+     * 獲取實時會話列表
+     */
+    SessionDataManager.prototype.fetchRealtimeSessions = function(lang) {
+        return fetch('/api/all-sessions?lang=' + lang)
+            .then(function(response) {
+                if (!response.ok) {
+                    throw new Error('獲取實時會話狀態失敗: ' + response.status);
+                }
+                return response.json();
+            })
+            .then(function(data) {
+                if (data && Array.isArray(data.sessions)) {
+                    return data.sessions;
+                }
+                throw new Error('實時會話狀態回應格式錯誤');
+            });
+    };
+
+    /**
+     * 從歷史文件獲取會話列表
+     */
+    SessionDataManager.prototype.fetchHistorySessions = function(lang) {
+        return fetch('/api/load-session-history?lang=' + lang)
+            .then(function(response) {
+                if (!response.ok) {
+                    throw new Error('伺服器回應錯誤: ' + response.status);
+                }
+                return response.json();
+            })
+            .then(function(data) {
+                if (data && Array.isArray(data.sessions)) {
+                    return data.sessions;
+                }
+                return [];
+            });
+    };
+
+    /**
+     * 按 session_id 合併會話，優先使用實時數據，保留歷史中的完整記錄
+     */
+    SessionDataManager.prototype.mergeSessionsById = function(historySessions, realtimeSessions) {
+        const sessionMap = new Map();
+
+        historySessions.forEach(function(session) {
+            if (session && session.session_id) {
+                sessionMap.set(session.session_id, session);
+            }
+        });
+
+        realtimeSessions.forEach(function(session) {
+            if (!session || !session.session_id) {
+                return;
+            }
+
+            const existing = sessionMap.get(session.session_id);
+            if (existing) {
+                // 實時資料覆蓋狀態類欄位，保留歷史資料中的補充欄位
+                sessionMap.set(session.session_id, Object.assign({}, existing, session));
+            } else {
+                sessionMap.set(session.session_id, session);
+            }
+        });
+
+        return Array.from(sessionMap.values()).sort(function(a, b) {
+            const aTime = a.created_at || a.saved_at || 0;
+            const bTime = b.created_at || b.saved_at || 0;
+            return bTime - aTime;
+        });
+    };
+
+    /**
      * 合併會話數據
      */
     SessionDataManager.prototype.mergeSessionData = function(existingData, newData) {
@@ -632,45 +703,39 @@
      */
     SessionDataManager.prototype.loadFromServer = function() {
         const self = this;
-
-        // 首先嘗試獲取實時會話狀態
         const lang = window.i18nManager ? window.i18nManager.getCurrentLanguage() : 'zh-TW';
-        fetch('/api/all-sessions?lang=' + lang)
-            .then(function(response) {
-                if (response.ok) {
-                    return response.json();
-                } else {
-                    throw new Error('獲取實時會話狀態失敗: ' + response.status);
-                }
-            })
-            .then(function(data) {
-                if (data && Array.isArray(data.sessions)) {
-                    // 使用實時會話狀態
-                    self.sessionHistory = data.sessions;
-                    console.log('📊 從伺服器載入', self.sessionHistory.length, '個實時會話狀態');
 
-                    // 載入完成後進行清理和統計更新
-                    self.cleanupExpiredSessions();
-                    self.updateStats();
+        Promise.allSettled([
+            self.fetchRealtimeSessions(lang),
+            self.fetchHistorySessions(lang)
+        ]).then(function(results) {
+            const realtimeResult = results[0];
+            const historyResult = results[1];
 
-                    // 觸發歷史記錄變更回調
-                    if (self.onHistoryChange) {
-                        self.onHistoryChange(self.sessionHistory);
-                    }
+            const realtimeSessions = realtimeResult.status === 'fulfilled' ? realtimeResult.value : [];
+            const historySessions = historyResult.status === 'fulfilled' ? historyResult.value : [];
 
-                    // 觸發資料變更回調
-                    if (self.onDataChanged) {
-                        self.onDataChanged();
-                    }
-                } else {
-                    console.warn('📊 實時會話狀態回應格式錯誤，回退到歷史文件');
-                    self.loadFromHistoryFile();
-                }
-            })
-            .catch(function(error) {
-                console.warn('📊 獲取實時會話狀態失敗，回退到歷史文件:', error);
-                self.loadFromHistoryFile();
-            });
+            if (realtimeResult.status === 'rejected') {
+                console.warn('📊 獲取實時會話狀態失敗:', realtimeResult.reason);
+            }
+            if (historyResult.status === 'rejected') {
+                console.warn('📊 載入歷史文件失敗:', historyResult.reason);
+            }
+
+            self.sessionHistory = self.mergeSessionsById(historySessions, realtimeSessions);
+            console.log('📊 初始化會話資料完成：歷史', historySessions.length, '個，實時', realtimeSessions.length, '個，合併後', self.sessionHistory.length, '個');
+
+            self.cleanupExpiredSessions();
+            self.updateStats();
+
+            if (self.onHistoryChange) {
+                self.onHistoryChange(self.sessionHistory);
+            }
+
+            if (self.onDataChanged) {
+                self.onDataChanged();
+            }
+        });
     };
 
     /**

--- a/src/mcp_feedback_enhanced/web/static/js/modules/websocket-manager.js
+++ b/src/mcp_feedback_enhanced/web/static/js/modules/websocket-manager.js
@@ -43,6 +43,7 @@
         // 待處理的提交
         this.pendingSubmission = null;
         this.sessionUpdatePending = false;
+        this.sessionId = options.sessionId || null;
 
         // 網路狀態檢測
         this.networkOnline = navigator.onLine;
@@ -83,9 +84,14 @@
                 this.websocket = null;
             }
 
-            // 添加語言參數到 WebSocket URL
+            // 添加語言與會話參數到 WebSocket URL
             const language = window.i18nManager ? window.i18nManager.getCurrentLanguage() : 'zh-TW';
-            const wsUrlWithLang = wsUrl + (wsUrl.includes('?') ? '&' : '?') + 'lang=' + language;
+            const urlParams = new URLSearchParams(window.location.search);
+            const sessionId = this.sessionId || urlParams.get('session_id');
+            let wsUrlWithLang = wsUrl + (wsUrl.includes('?') ? '&' : '?') + 'lang=' + encodeURIComponent(language);
+            if (sessionId) {
+                wsUrlWithLang += '&session_id=' + encodeURIComponent(sessionId);
+            }
             this.websocket = new WebSocket(wsUrlWithLang);
             this.setupWebSocketEvents();
 


### PR DESCRIPTION


## 🔍 背景与问题
本 PR 聚焦修复两个实际使用中的会话一致性问题：
1. #169：多项目/多工作区并行操作时，前端与后端会话绑定不稳定，消息容易“跟着最新会话走”。
2. #177：会话历史在前端加载过程中被实时列表覆盖，只保留最新记录，较早会话丢失。

## 🧩 根因分析
### #169（会话路由错配）
- 后端依赖“当前会话”概念，缺少按 `session_id` 精确绑定的统一入口。
- 前端 WebSocket 与部分 API 请求未稳定透传 `session_id`。
- 会话更新标记是单值语义，不能准确覆盖多会话并行情形。

### #177（历史记录覆盖）
- 前端 `loadFromServer` 主要依赖 `/api/all-sessions` 作为单一数据源。
- 实时会话列表天然偏短，导致历史会话在 UI 层被覆盖/丢失。

## 🛠️ 主要改动
### 1) 后端：引入“工作区 + 会话”双维度管理（`src/mcp_feedback_enhanced/web/main.py`）
- 新增会话更新集合：`_pending_session_updates: set[str]`（按会话追踪待通知状态）。
- 新增工作区映射：`workspace_current_sessions: dict[str, str]`（工作区 -> 当前会话）。
- 新增 `_workspace_key(project_directory)`，对目录路径做归一化，避免路径表示差异导致冲突。
- 新增 `get_session_by_id(session_id)`，统一支持“显式会话”与“回退当前会话”获取逻辑。
- `create_session()` 改为优先按工作区查找旧会话并维护映射；创建后返回 `session_id` 供全链路使用。
- 会话清理/移除流程同步维护 `workspace_current_sessions` 与 `_pending_session_updates`，避免脏映射。
- `launch_web_feedback_ui()` 入口 URL 改为 `/?session_id=<id>`，确保页面实例与目标会话一一对应。

### 2) 路由层：HTTP + WebSocket 全链路支持 `session_id`（`src/mcp_feedback_enhanced/web/routes/main_routes.py`）
- 以下接口新增可选参数 `session_id`，并统一改为 `manager.get_session_by_id(session_id)`：
  - `GET /`
  - `GET /api/session-status`
  - `GET /api/current-session`
  - `POST /api/add-user-message`
  - `GET /ws`（WebSocket）
- WebSocket 连接建立、消息处理、断连清理均基于“绑定会话”执行，不再依赖全局当前会话。
- `/api/all-sessions` 在返回实时会话后，补充读取 `~/.config/mcp-feedback-enhanced/session_history.json` 历史数据并去重，降低历史缺失风险。

### 3) 前端：会话 ID 透传与历史合并（`src/mcp_feedback_enhanced/web/static/js/*.js`）
- `app.js`
  - 初始化时从 URL 自动读取 `session_id`，并设置 `currentSessionId`。
  - 初始化 WebSocketManager 时显式传入 `sessionId`。
  - 刷新当前会话时请求 `/api/current-session?session_id=...`。
- `websocket-manager.js`
  - 新增 `options.sessionId`。
  - 建立连接时将 `lang` 与 `session_id` 一并写入 WebSocket URL。
- `session-data-manager.js`
  - 新增 `fetchRealtimeSessions(lang)` 与 `fetchHistorySessions(lang)`。
  - 新增 `mergeSessionsById(historySessions, realtimeSessions)`，按 `session_id` 合并且优先实时状态字段。
  - `loadFromServer()` 改为 `Promise.allSettled` 并行拉取后合并，避免历史被覆盖。
  - `sendUserMessageToServer()` 上报时追加 `session_id` 查询参数，保证消息写入目标会话。
